### PR TITLE
setup.sh を mac で動くようにしました

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,7 +30,8 @@ run cd -
 
 run git clone git://github.com/ranguba/rroonga.git
 run cd rroonga
-run PKG_CONFIG_PATH=${base_dir}/lib/pkgconfig ${RUBY} extconf.rb
+run export PKG_CONFIG_PATH=${base_dir}/local/lib/pkgconfig
+run ${RUBY} extconf.rb
 run make
 run cd -
 


### PR DESCRIPTION
setup.sh が mac だと上手く動かなかったのですが，
手元で修正したら動くようになったので送ります．

ruby のサフィックス(1.9.1)はどうしたらいいのかわかりませんでした…
手元ではサフィックスを抜いた状態に書き変えて実行しました．
