### PR TITLE
るりまプロジェクトへのリンクが切れていた

### DIFF
--- a/views/layout.html.erb
+++ b/views/layout.html.erb
@@ -32,7 +32,7 @@
   <div class="footer">
     <p class="rurema">
      検索対象のドキュメントは
-     <a href="http://redmine.ruby-lang.org/wiki/rurema">るりま</a>
+     <a href="http://redmine.ruby-lang.org/projects/rurema">るりまプロジェクト</a>
      の成果物です。
     </p>
     <p class="powered-by">


### PR DESCRIPTION
リンクのテキストは、redmineのタイトルになっている"るりまプロジェクト"のほうが適切かと思いました。
