### PR TITLE
Fix rurema project page

### DIFF
--- a/views/layout.html.erb
+++ b/views/layout.html.erb
@@ -32,7 +32,7 @@
   <div class="footer">
     <p class="rurema">
      検索対象のドキュメントは
-     <a href="http://redmine.ruby-lang.org/projects/rurema">るりまプロジェクト</a>
+     <a href="http://bugs.ruby-lang.org/projects/rurema">るりまプロジェクト</a>
      の成果物です。
     </p>
     <p class="powered-by">


### PR DESCRIPTION
I fix a link to the rurema project page.
http://redmine.ruby-lang.org/projects/rurema returns 404 now.
redmine.ruby-lang.org has been moved to bugs.ruby-lang.org.
