### PR TITLE
Replace obsoleted url and remove debug comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,9 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-source "http://rubygems.org/"
+source "https://rubygems.org/"
 
-gem "rroonga"#, :git => "https://github.com/ranguba/rroonga.git"
+gem "rroonga"
 gem "racknga"
 gem "bitclust-core"
 gem "bitclust-dev"


### PR DESCRIPTION
rubygems suggest to use https protocol. I replace https from http. and remvoed debug like message. If you hope to make local develop env, you can use "Local Git Repos" on http://bundler.io/git.html.
