### PR TITLE
Fix URL of Rroonga

### DIFF
--- a/views/layout.html.erb
+++ b/views/layout.html.erb
@@ -42,7 +42,7 @@
       を使っています。
     <p class="powered-by">
       Groongaは
-      <a href="http://groonga.rubyforge.org/">Rroonga</a>
+      <a href="http://ranguba.org/">Rroonga</a>
       <%= h(Groonga::BINDINGS_VERSION.join(".")) %>
       経由で利用しています。
     </p>


### PR DESCRIPTION
RubyForge.org has been shutdown. groonga.rubyforge.org has been replaced by http://ranguba.org.
