### PR TITLE
Update OpenSearch according to latest specs

### DIFF
--- a/test/test-open-search.rb
+++ b/test/test-open-search.rb
@@ -35,6 +35,6 @@ class OpenSearchTest < Test::Unit::TestCase
                  content_type)
     xml = Nokogiri::XML(page.source)
     url = xml.xpath("//node()[name()='Url']")[0]
-    assert_equal(expected_template, url["template"])
+    assert_equal("#{expected_template}?query={searchTerms}", url["template"])
   end
 end

--- a/views/open_search_description.xml.erb
+++ b/views/open_search_description.xml.erb
@@ -5,8 +5,6 @@
   <Description><%= h(site_description) %></Description>
   <Image height="16" width="16" type="image/png"><%= h(base_url + "favicon.png") %></Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url type="text/html" method="get" template="<%= h(version_url) %>">
-    <Param name="query" value="{searchTerms}" />
-  </Url>
+  <Url type="text/html" method="get" template="<%= h(version_url) %>?query={searchTerms}" />
   <moz:SearchForm><%= h(version_url) %></moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
When I search on rurema via OpenSearch, it goes to `http://rurema.clear-code.com/?searchTerms={{searchTerms}}`.   This issue occurs on Safari 9.1 for OS X 10.11.4.

The `<Param/>` element does not exist in latest specifications of OpenSearch.

> Moved the `<Param/>` element and the `<Url/>` element's 'method' attribute to the OpenSearch parameter extension.
> <http://www.opensearch.org/Specifications/OpenSearch/Changelog>
