### PR TITLE
Fix RDAttributesExtractor.new

### DIFF
--- a/lib/rurema_search/groonga_indexer.rb
+++ b/lib/rurema_search/groonga_indexer.rb
@@ -210,7 +210,8 @@ module RuremaSearch
 
     class RDAttributesExtractor < BitClust::RDCompiler
       def initialize
-        super(nil)
+        opt = {:stop_on_syntax_error => false}
+        super(nil, 1, opt)
       end
 
       def extract(src)


### PR DESCRIPTION
GroongaIndexer fails to create index when `BitClust::SyntaxHighlighter::ParseError` occurs.

##  The index of 2.7.0 stopped in the middle.

![index_error](https://user-images.githubusercontent.com/16305594/97024278-93db5c00-1591-11eb-9b2c-d7cef0115d83.png)

## After applying this patch, the index value will be fine.

![fix_index_error](https://user-images.githubusercontent.com/16305594/97024368-b1a8c100-1591-11eb-879b-d4a2636cd9ed.png)
