### PR TITLE
Fix missing DocumentRoot

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -162,4 +162,21 @@ end
 
 use Racknga::Middleware::InstanceName, :application_name => "Rurema Search"
 
+# URL mapping to the version directory.
+versions = database.entries.group("version").sort(["_key"], :limit => -1)
+versions.each do |version|
+  version_dir = version["_key"].to_s
+  map "/#{version_dir}" do
+    run Rack::Directory.new("#{base_dir}/public/#{version_dir}")
+  end
+end
+
+# URL mapping to the css, images and javascripts directory.
+directories = ["css", "images", "javascripts"]
+directories.each do |directory|
+  map "/#{directory}" do
+    run Rack::Directory.new("#{base_dir}/public/#{directory}")
+  end
+end
+
 run searcher


### PR DESCRIPTION
rurema-search has lost sight of the file in the DocumentRoot.

![fix_index_error](https://user-images.githubusercontent.com/16305594/97028349-f3883600-1596-11eb-8fb5-f0a89de7d758.png)

## After applying this patch.

![Fix_missing_DocumentRoot](https://user-images.githubusercontent.com/16305594/97028371-fc790780-1596-11eb-913f-b8b6ad04e15a.png)

