### PR TITLE
Fix kana cast error

### DIFF
--- a/lib/rurema_search/groonga_suggest_database.rb
+++ b/lib/rurema_search/groonga_suggest_database.rb
@@ -71,9 +71,9 @@ module RuremaSearch
       @context.receive
 
       item_values = []
-      item_values << {"_key" => keyword, "kana" => keyword}
+      item_values << {"_key" => keyword, "kana" => [keyword]}
       related_keywords.each do |related_keyword|
-        item_values << {"_key" => related_keyword, "kana" => related_keyword}
+        item_values << {"_key" => related_keyword, "kana" => [related_keyword]}
       end
       @context.send("load --table #{table_name('item')}")
       @context.send(JSON.generate(item_values))


### PR DESCRIPTION
"failed to cast to kana" error has occurred. This patch solves this error.

```
Traceback (most recent call last):
        11: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:121:in `<main>'
        10: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:114:in `main'
         9: from /home/icm7216/rurema/rurema-search/lib/rurema_search/groonga_database.rb:31:in `open'
         8: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:117:in `block in main'
         7: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:76:in `update_suggest_database'
         6: from /home/icm7216/rurema/rurema-search/lib/rurema_search/groonga_suggest_database.rb:29:in `open'
         5: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:78:in `block in update_suggest_database'
         4: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:43:in `load_suggest_data'
         3: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:43:in `each'
         2: from /home/icm7216/rurema/rurema-search/bin/bitclust-indexer:69:in `block in load_suggest_data'
         1: from /home/icm7216/rurema/rurema-search/lib/rurema_search/groonga_suggest_database.rb:81:in `register_keyword'
/home/icm7216/rurema/rurema-search/lib/rurema_search/groonga_suggest_database.rb:81:in `send': invalid argument: <item_rurema.kana>: failed to cast to <kana>: <"new">: #<Groonga::Context encoding: <:utf8>, database: <#<Groonga::Database id: <nil>, name: (anonymous), path: </home/icm7216/rurema/rurema-search/var/lib/suggest/suggest.db>, domain: (nil), range: (nil), flags: <>>>> (Groonga::InvalidArgument)
store.c:2793: grn_ja_cast_value_vector_fixed_bulk()
```
